### PR TITLE
Implement functional options pattern

### DIFF
--- a/gohttp.go
+++ b/gohttp.go
@@ -152,9 +152,8 @@ func SerializeRequest(r *http.Request) ([]byte, error) {
 // ParseResponse reads a given source and parses an http.Response instance
 // from it.
 //
-// The option AllowLFLineEndings allows the header fields and the empty
-// line terminating the header section to be LF instead of CRLF endings. 
-// line terminating the header section may be LF instead of CRLF endings.
+// The option WithLFLineEndings allows the header fields and the empty line
+// terminating the header section to be LF instead of CRLF endings.
 func ParseResponse(reader *bufio.Reader, options ...Option) (*http.Response, error) {
 	config := newConfig(options...)
 	response := http.Response{}

--- a/gohttp.go
+++ b/gohttp.go
@@ -152,7 +152,8 @@ func SerializeRequest(r *http.Request) ([]byte, error) {
 // ParseResponse reads a given source and parses an http.Response instance
 // from it.
 //
-// If the user allows LF line endings, the header fields and the empty
+// The option AllowLFLineEndings allows the header fields and the empty
+// line terminating the header section to be LF instead of CRLF endings. 
 // line terminating the header section may be LF instead of CRLF endings.
 func ParseResponse(reader *bufio.Reader, options ...Option) (*http.Response, error) {
 	config := newConfig(options...)

--- a/gohttp.go
+++ b/gohttp.go
@@ -16,14 +16,29 @@ import (
 	"unicode"
 )
 
-var (
-	allowLFLineEndings = false
-)
+type config struct {
+	allowLFLineEndings bool
+}
+
+func newConfig(options ...Option) config {
+	var config config
+
+	for _, option := range options {
+		option(&config)
+	}
+
+	return config
+}
+
+// Option represents a function that modifies the passed config instance.
+type Option func(*config)
 
 // AllowLFLineEndings defines whether LF line endings are allowed for more
 // tolerant parsing. Use with care!
-func AllowLFLineEndings(allow bool) {
-	allowLFLineEndings = allow
+func AllowLFLineEndings(allow bool) Option {
+	return func(c *config) {
+		c.allowLFLineEndings = allow
+	}
 }
 
 // ParseRequest reads a given source and parses an http.Request instance
@@ -31,7 +46,8 @@ func AllowLFLineEndings(allow bool) {
 //
 // If the user allows LF line endings, the header fields and the empty
 // line terminating the header section may be LF instead of CRLF endings.
-func ParseRequest(reader *bufio.Reader) (*http.Request, error) {
+func ParseRequest(reader *bufio.Reader, options ...Option) (*http.Request, error) {
+	config := newConfig(options...)
 	request := http.Request{}
 
 	// RFC 7230, section 3.5. states that a robust parser implementation
@@ -42,7 +58,7 @@ func ParseRequest(reader *bufio.Reader) (*http.Request, error) {
 			return nil, err
 		}
 
-		if !isNewLine(line) {
+		if !isNewLine(line, config) {
 			method, targetUrl, protocol, err := parseRequestLine(line)
 			if err != nil {
 				return nil, err
@@ -70,7 +86,7 @@ func ParseRequest(reader *bufio.Reader) (*http.Request, error) {
 			break
 		}
 
-		if isNewLine(line) {
+		if isNewLine(line, config) {
 			break
 		}
 
@@ -82,7 +98,7 @@ func ParseRequest(reader *bufio.Reader) (*http.Request, error) {
 		request.Header.Add(fieldName, fieldValue)
 	}
 
-	if !isNewLine(line) {
+	if !isNewLine(line, config) {
 		return nil, errors.New("empty line after header section is missing")
 	}
 
@@ -138,7 +154,8 @@ func SerializeRequest(r *http.Request) ([]byte, error) {
 //
 // If the user allows LF line endings, the header fields and the empty
 // line terminating the header section may be LF instead of CRLF endings.
-func ParseResponse(reader *bufio.Reader) (*http.Response, error) {
+func ParseResponse(reader *bufio.Reader, options ...Option) (*http.Response, error) {
+	config := newConfig(options...)
 	response := http.Response{}
 
 	line, err := reader.ReadString('\n')
@@ -167,7 +184,7 @@ func ParseResponse(reader *bufio.Reader) (*http.Response, error) {
 			break
 		}
 
-		if isNewLine(line) {
+		if isNewLine(line, config) {
 			break
 		}
 
@@ -179,7 +196,7 @@ func ParseResponse(reader *bufio.Reader) (*http.Response, error) {
 		response.Header.Add(fieldName, fieldValue)
 	}
 
-	if !isNewLine(line) {
+	if !isNewLine(line, config) {
 		return nil, errors.New("empty line after header section is missing")
 	}
 
@@ -334,8 +351,8 @@ func determineBodyLength(headers http.Header, reader *bufio.Reader) (int, error)
 	return 0, nil
 }
 
-func isNewLine(line string) bool {
-	if allowLFLineEndings {
+func isNewLine(line string, config config) bool {
+	if config.allowLFLineEndings {
 		return line == "\r\n" || line == "\n"
 	}
 	return line == "\r\n"

--- a/gohttp.go
+++ b/gohttp.go
@@ -33,9 +33,9 @@ func newConfig(options ...Option) config {
 // Option represents a function that modifies the passed config instance.
 type Option func(*config)
 
-// AllowLFLineEndings defines whether LF line endings are allowed for more
+// WithLFLineEndings defines whether LF line endings are allowed for more
 // tolerant parsing. Use with care!
-func AllowLFLineEndings(allow bool) Option {
+func WithLFLineEndings(allow bool) Option {
 	return func(c *config) {
 		c.allowLFLineEndings = allow
 	}

--- a/gohttp_test.go
+++ b/gohttp_test.go
@@ -36,11 +36,9 @@ Host: www.example.com
 		},
 	}
 
-	AllowLFLineEndings(true)
-
 	for name, tc := range testCases {
 		reader := bufio.NewReader(strings.NewReader(tc.source))
-		actual, err := ParseRequest(reader)
+		actual, err := ParseRequest(reader, WithLFLineEndings(true))
 		if err != nil {
 			t.Fatalf("'%s': unexpected error: %s", name, err.Error())
 		}


### PR DESCRIPTION
This PR introduces [functional options](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) for gohttp. Settings won't be globally stored anymore, but function-scoped instead.

**Before this change:**

```go
gohttp.AllowLFLineEndings(true)
_, _ = gohttp.ParseRequest(source)
```

**After this change:**

```go
_, _ = gohttp.ParseRequest(source, gohttp.AllowLFLineEndings(true))
```